### PR TITLE
Free allocated char* with C.CString

### DIFF
--- a/go/process.go
+++ b/go/process.go
@@ -156,7 +156,10 @@ func (p *ProcessDesc) SetParentDeathSignal(sig syscall.Signal) error {
 }
 
 func (p *ProcessDesc) SetLSMLabel(label string) error {
-	if ret := C.libct_process_desc_set_lsm_label(p.desc, C.CString(label)); ret != 0 {
+	clabel := C.CString(label)
+	defer C.free(unsafe.Pointer(clabel))
+
+	if ret := C.libct_process_desc_set_lsm_label(p.desc, clabel); ret != 0 {
 		return LibctError{int(ret)}
 	}
 


### PR DESCRIPTION
If you allocated char\* using C.CString you're responsible for free memory. It's not a full fix, as I haven't come across all the code to find out free policy for all exported C functions.
I can go on this PR if it makes sence
